### PR TITLE
stubby: do not enforce TLS 1.3

### DIFF
--- a/release/src/router/rc/services.c
+++ b/release/src/router/rc/services.c
@@ -1277,8 +1277,6 @@ void start_stubby(int force)
 				fprintf(fp, "tls_authentication: GETDNS_AUTHENTICATION_NONE\n");
 				logmessage("stubby-proxy", "configured opportunistic mode");
 			}
-			fprintf(fp, "tls_min_version: GETDNS_TLS1_3\n");	// force TLS1.3
-			fprintf(fp, "tls_ciphersuites: \"TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256\"\n");	// set ciphers
 			if (nvram_match("dnssec_enable", "1") && nvram_match("stubby_dnssec", "1")) {
 				fprintf(fp, "dnssec: GETDNS_EXTENSION_TRUE\n");
 				logmessage("stubby-proxy", "DNSSEC enabled");


### PR DESCRIPTION
Prevent issues that broke Cloudflare DoT earlier in Nov 2019. Accept stubby defaults.

https://www.snbforums.com/threads/fork-asuswrt-merlin-374-43-lts-releases-v39e3.18914/page-491#post-527423