### PR TITLE
Fix red component banners in Makefile

### DIFF
--- a/release/src/router/Makefile
+++ b/release/src/router/Makefile
@@ -96,7 +96,7 @@ endif
 #
 #
 #
-SEP=echo "\033[41;1m   $@   \033[0m"
+SEP=printf "\033[41;1m   $@   \033[0m\n"
 
 #
 # standard packages


### PR DESCRIPTION
Change `echo` to `printf` as in upstream, so the nice red progress banners are displayed correctly during builds.