### PR TITLE
Parallel build rc, nettle, wget, e2fsprogs

### DIFF
--- a/release/src/router/Makefile
+++ b/release/src/router/Makefile
@@ -1072,7 +1072,7 @@ else
 endif
 
 e2fsprogs: e2fsprogs/Makefile
-	$(MAKE) -C $@
+	$(MAKE) -C $@ $(PARALLEL_BUILD)
 
 e2fsprogs-clean:
 	-@$(MAKE) -C e2fsprogs clean
@@ -1290,6 +1290,8 @@ wb: openssl libxml2 curl
 push_log: wb
 
 rc: shared nvram$(BCMEX)libbcmcrypto libdisk $(PUSH_LOG) $(if $(RTCONFIG_QTN),libqcsapi_client) $(if $(CONFIG_LIBBCM),libbcm)
+	@$(SEP)
+	@$(MAKE) -C rc $(PARALLEL_BUILD)
 
 rc-install:
 	$(MAKE) -C rc INSTALLDIR=$(INSTALLDIR)/rc install
@@ -1519,9 +1521,9 @@ nettle/stamp-h1:
 	@touch nettle/stamp-h1
 
 nettle: nettle/stamp-h1
-	$(SEP)
-	$(MAKE) -C nettle
-	$(MAKE) -C nettle install
+	@$(SEP)
+	@$(MAKE) -C nettle $(PARALLEL_BUILD)
+	@$(MAKE) -C nettle install
 
 nettle-clean:
 	-@$(MAKE) -C nettle clean
@@ -3901,7 +3903,7 @@ wget/Makefile: wget/Makefile.in
 		LDFLAGS="$(EXTRALDFLAGS) -Wl,--gc-sections -L$(TOP)/openssl-1.1 -lssl -lcrypto -L$(TOP)/zlib -lz -lpthread"
 
 wget: openssl-1.1 zlib wget/Makefile
-	$(MAKE) -C $@
+	$(MAKE) -C $@ $(PARALLEL_BUILD)
 
 wget-clean:
 	[ ! -f wget/Makefile ] || $(MAKE) -C wget distclean


### PR DESCRIPTION
These are all parallel built upstream.

Reduces clean build time for those 4 components from 3m15 to 1m48 on my system (but I do have a lot of cores).